### PR TITLE
Fix issue with build meta-data not being parsed without a pre-release…

### DIFF
--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -168,11 +168,20 @@ Version::Version(const string& s)
   m_majorVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
   if (!getline(ss, part, '.')) return;
   m_minorVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
-  if (!getline(ss, part, '-')) return;
+  if (!getline(ss, part)) return;
   m_patchVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
 
-  if (!getline(ss, m_prereleaseVersion, '+')) return;
-  getline(ss, m_buildVersion, '\0');
+  const size_t preLoc = part.find_first_of("-");
+  const size_t buildLoc = part.find_first_of("+");
+
+  if (preLoc != string::npos) {
+    const size_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
+    m_prereleaseVersion = part.substr(preLoc+1, length);
+  }
+
+  if (buildLoc != string::npos) {
+    m_buildVersion = part.substr(buildLoc + 1, string::npos);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -255,15 +255,63 @@ DEF_TEST(ConstructFromString, SemanticVersion)
   return s.str() == "1.2.3-alpha.2+build.1234";
 }
 
+DEF_TEST(ConstructFromStringOnlyPrerelease, SemanticVersion)
+{
+  Version v("1.2.3-alpha.2");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3-alpha.2";
+}
+
+DEF_TEST(ConstructFromStringOnlyMeta, SemanticVersion)
+{
+  Version v("1.2.3+build.1234");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3+build.1234";
+}
+
+DEF_TEST(ConstructFromStringNoPrereleaseNoMeta, SemanticVersion)
+{
+  Version v("1.2.3");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3";
+}
+
 DEF_TEST(WellFormed, SemanticVersion)
 {
   Version v("1.2.3-alpha.2+build.1234");
   return v.IsWellFormed();
 }
 
+DEF_TEST(WellFormedOnlyPrerelease, SemanticVersion)
+{
+  Version v("1.2.3-alpha.2");
+  return v.IsWellFormed();
+}
+
+DEF_TEST(WellFormedOnlyMeta, SemanticVersion)
+{
+  Version v("1.2.3+build.1234");
+  return v.IsWellFormed();
+}
+
+DEF_TEST(WellFormedNoPrereleaseNoMeta, SemanticVersion)
+{
+  Version v("1.2.3");
+  return v.IsWellFormed();
+}
+
 DEF_TEST(ParseIllFormed, SemanticVersion)
 {
   Version v("1.2.3-alpha-2+build+1234");
+  return !v.IsWellFormed();
+}
+
+DEF_TEST(ParseIllFormedSwapped, SemanticVersion)
+{
+  Version v("1.2.3+build+1234-alpha-2");
   return !v.IsWellFormed();
 }
 


### PR DESCRIPTION
Add support for build metadata without pre-release version as per spec-items 9 & 10

https://semver.org/#spec-item-9
https://semver.org/#spec-item-10